### PR TITLE
Use SystemPalette for dynamic theme-aware text colors

### DIFF
--- a/package/contents/config/main.xml
+++ b/package/contents/config/main.xml
@@ -48,8 +48,11 @@
         <entry name="use_24_hour_format" type="Bool">
             <default>false</default>
         </entry>
+        <entry name="follow_system_text_color" type="Bool">
+            <default>true</default>
+        </entry>
         <entry name="time_character" type="String">
             <default>-</default>
         </entry>
     </group>
-</kcfg> 
+</kcfg>

--- a/package/contents/ui/configAppearance.qml
+++ b/package/contents/ui/configAppearance.qml
@@ -23,8 +23,13 @@ Kirigami.ScrollablePage {
     property alias cfg_time_character: timeCharacter.text
     property alias cfg_date_format: dateFormat.text
     property alias cfg_date_font_color: dateFontColor.color
+    property alias cfg_follow_system_text_color: followSystemTextColor.checked
 
     Kirigami.FormLayout {
+        RowLayout {
+            Label { text: i18n("Follow system text color") }
+            CheckBox { id: followSystemTextColor }
+        }
         Title {
             title: i18n("Day")
         }
@@ -47,6 +52,7 @@ Kirigami.ScrollablePage {
         ColorDial {
             id: dayFontColor
             color: cfg_day_font_color
+            enabled: !followSystemTextColor.checked
         }
         Title {
             title: i18n("Date")
@@ -78,6 +84,7 @@ Kirigami.ScrollablePage {
         ColorDial {
             id: dateFontColor
             color: cfg_date_font_color
+            enabled: !followSystemTextColor.checked
         }
 
         Title {
@@ -119,6 +126,7 @@ Kirigami.ScrollablePage {
         ColorDial {
             id: timeFontColor
             color: cfg_time_font_color
+            enabled: !followSystemTextColor.checked
         }
     }
 }

--- a/package/contents/ui/main.qml
+++ b/package/contents/ui/main.qml
@@ -7,6 +7,10 @@ import org.kde.plasma.core as PlasmaCore
 import org.kde.plasma.plasma5support as Plasma5Support
 
 PlasmoidItem {
+    SystemPalette {
+        id: sysPalette
+        colorGroup: SystemPalette.Active
+    }
     id: root
     
     
@@ -80,9 +84,12 @@ PlasmoidItem {
                 font.pixelSize: plasmoid.configuration.day_font_size
                 font.letterSpacing: plasmoid.configuration.day_letter_spacing
                 font.family: font_anurati.name
-                color: plasmoid.configuration.day_font_color
                 anchors.horizontalCenter: parent.horizontalCenter
                 horizontalAlignment: Text.AlignHCenter 
+
+                color: plasmoid.configuration.follow_system_text_color
+                ? sysPalette.windowText
+                : plasmoid.configuration.day_font_color
             }
 
             // The Date
@@ -96,9 +103,12 @@ PlasmoidItem {
                 font.pixelSize: plasmoid.configuration.date_font_size
                 font.letterSpacing: plasmoid.configuration.date_letter_spacing
                 font.family: font_poppins.name
-                color: plasmoid.configuration.date_font_color
                 horizontalAlignment: Text.AlignHCenter
                 anchors.horizontalCenter: parent.horizontalCenter
+
+                color: plasmoid.configuration.follow_system_text_color
+                ? sysPalette.windowText
+                : plasmoid.configuration.date_font_color
             }
 
             // The Time
@@ -111,10 +121,13 @@ PlasmoidItem {
                 // font settings
                 font.pixelSize: plasmoid.configuration.time_font_size
                 font.family: font_poppins.name
-                color: plasmoid.configuration.time_font_color
                 font.letterSpacing: plasmoid.configuration.time_letter_spacing
                 horizontalAlignment: Text.AlignHCenter
                 anchors.horizontalCenter: parent.horizontalCenter
+
+                color: plasmoid.configuration.follow_system_text_color
+                ? sysPalette.windowText
+                : plasmoid.configuration.time_font_color
             }
         }
     }


### PR DESCRIPTION
## Summary

This PR adds optional support for using the current system/Plasma theme text color for the clock labels.

Previously, day, date, and time text relied only on manually configured colors. This could make the widget unreadable when switching between light and dark Plasma themes.

## Changes

- add a new `follow_system_text_color` config option
- expose the option in the appearance settings
- disable manual color pickers while the option is enabled
- use `SystemPalette.windowText` for day, date, and time when the option is enabled
- keep the existing manual color behavior when the option is disabled

## Why this approach

Other theme-color approaches did not behave correctly during testing on Fedora 43 / KDE Plasma 6.6.3.  
`SystemPalette.windowText` correctly followed live Plasma light/dark theme changes in actual use.

## Result

With this change:
- the widget can automatically follow the active Plasma theme text color
- manual color selection still works as before when theme-following is disabled

## Fixes

Fixes #14